### PR TITLE
Update pre-requisites

### DIFF
--- a/docs/modules/ROOT/pages/spring-session-hazelcast.adoc
+++ b/docs/modules/ROOT/pages/spring-session-hazelcast.adoc
@@ -18,8 +18,8 @@ https://docs.spring.io/spring-session/reference/index.html[Spring Session Docume
 
 == Before you Begin
 
-- JDK 1.8+
-- Apache Maven 3.2+
+- JDK 17+
+- Apache Maven 3.8+
 
 == Enable HazelcastHttpSession
 


### PR DESCRIPTION
Hazelcast 5.4+ requires Java 11.

I think it would be more sensible to link to the main docs for this info, but as a quick-fix replicated whats in [another tutorial](https://docs.hazelcast.com/tutorials/hazelcast-embedded-microprofile).